### PR TITLE
add configurationTarget when updating settings

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -151,9 +151,9 @@ export const commandDescriptions = {
     ),
     setSetting: hidden(
         "Other",
-        "Set setting for vscode",
+        "Set setting for vscode, either globally or for the current workspace/folder",
         undefined,
-        "(section: string, value: any)"
+        "(section: string, value: any, configurationTarget: ConfigurationTarget)"
     ),
     executeCommands: hidden(
         "Other",

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -1,9 +1,33 @@
-import { workspace, ConfigurationTarget } from "vscode";
+import * as vscode from "vscode";
 
 export function getSetting<T>(section: string, defaultValue?: T): T | undefined {
-    return workspace.getConfiguration().get(section, defaultValue);
+    return vscode.workspace.getConfiguration().get(section, defaultValue);
 }
 
-export function setSetting(section: string, value: any, configurationTarget?: boolean | ConfigurationTarget) {
-    return workspace.getConfiguration().update(section, value, configurationTarget);
+type ConfigurationTarget = "global" | "workspace" | "workspaceFolder";
+
+export function setSetting(section: string, value: any, configurationTarget?: ConfigurationTarget) {
+    return vscode.workspace
+        .getConfiguration()
+        .update(
+            section,
+            value,
+            configurationTarget != null ? getConfigurationTarget(configurationTarget) : undefined
+        );
+}
+
+function getConfigurationTarget(
+    configurationTarget: ConfigurationTarget
+): vscode.ConfigurationTarget {
+    switch (configurationTarget) {
+        case "global":
+            return vscode.ConfigurationTarget.Global;
+        case "workspace":
+            return vscode.ConfigurationTarget.Workspace;
+        case "workspaceFolder":
+            return vscode.ConfigurationTarget.WorkspaceFolder;
+        default:
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            throw new Error(`Unknown configuration target: ${configurationTarget}`);
+    }
 }

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -1,9 +1,9 @@
-import { workspace } from "vscode";
+import { workspace, ConfigurationTarget } from "vscode";
 
 export function getSetting<T>(section: string, defaultValue?: T): T | undefined {
     return workspace.getConfiguration().get(section, defaultValue);
 }
 
-export function setSetting(section: string, value: any) {
-    return workspace.getConfiguration().update(section, value);
+export function setSetting(section: string, value: any, configurationTarget?: boolean | ConfigurationTarget) {
+    return workspace.getConfiguration().update(section, value, configurationTarget);
 }


### PR DESCRIPTION
Currently all settings updates must be done at the workspace level, this adds the option to target the global level while remaining backwards compatible 